### PR TITLE
spiflash: write_data() accepts PBYTES, too

### DIFF
--- a/spiflash.py
+++ b/spiflash.py
@@ -141,7 +141,7 @@ SpiFlash class
         pkt = bytearray()
         pkt.append(SERIAL_FLASH_CMD_WRITE)
         pkt.extend(_parse_addr(addr,3))
-        if type(data) == PBYTEARRAY:
+        if type(data) in (PBYTES, PBYTEARRAY):
             pkt.extend(data)
         elif type(data) == PLIST:
             for el in data:


### PR DESCRIPTION
`PBYTES` are the constant counterpart of `PBYTEARRAY`, which are accepted. Moreover, `read_data()` returns `PBYTES` via `spi.exchange()` (see [vbl_spi.c:98](https://github.com/zerynth/core-zerynth-stdlib/blob/be9178cc02c8c4ba942a15e7673a5cc44071200f/csrc/vbl/vbl_spi.c#L98)).