### PR TITLE
Mimic date and time + fix for large deltatime

### DIFF
--- a/datetime.py
+++ b/datetime.py
@@ -769,16 +769,19 @@ class datetime:
     MAXYEAR = 9999
 
     def __init__(self, year, month, day, hour=0, minute=0, second=0, tzinfo=None):
-        if not (self.MINYEAR <= year <= self.MAXYEAR and\
-                1 <= month  <= 12 and\
-                1 <= day    <= _days_in_month(year, month) and\
-                0 <= hour   <  24 and\
-                0 <= minute <  60 and\
-                0 <= second <  60):
+        if year == 0 and month == 0 and day > 0:
+            self._ord = day
+        elif self.MINYEAR <= year <= self.MAXYEAR\
+        and  1 <= month  <= 12\
+        and  1 <= day    <= _days_in_month(year, month)\
+        and  0 <= hour   <  24\
+        and  0 <= minute <  60\
+        and  0 <= second <  60:
+            self._ord = _ymd2ord(year, month, day)
+        else:
             raise ValueError
-        self._tz = tzinfo
-        self._ord = _ymd2ord(year, month, day)
         self._time = timedelta(hour, minute, second)
+        self._tz = tzinfo
 
     def add(self, other):
         time = self._time.add(other)
@@ -992,4 +995,4 @@ def fromisoformat(s):
 def fromordinal(n):
     if not 1 <= n <= 3652059:
         raise ValueError
-    return datetime(*_ord2ymd(n))
+    return datetime(0, 0, n)

--- a/datetime.py
+++ b/datetime.py
@@ -647,6 +647,10 @@ Examples of working with :class:`datetime` objects::
 
 """
 
+#-if 0
+import builtins as __builtins__
+#-endif
+
 # The following functions were (stolen and) adapted from Python's datetime.
 def _is_leap(year):
     return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)

--- a/datetime.py
+++ b/datetime.py
@@ -844,19 +844,7 @@ class datetime:
             days -= 1
             time = time.add(timedelta(days=-days))
         year, month, day, hour, minute, second, tz\
-                = self._tuple(self._ord, time, self._tz)[:7]
-        day += days
-        if day > _days_in_month(year, month):
-          day = 1
-          month += 1
-          if month > 12:
-            month = 1
-            year +=1
-        elif day < 1:
-          month -= 1
-          if month < 1:
-            year -= 1
-          day = _days_in_month(year, month)
+                = self._tuple(self._ord + days, time, self._tz)[:7]
         return datetime(year, month, day, hour, minute, second, tz)
 
     def sub(self, other):

--- a/datetime.py
+++ b/datetime.py
@@ -30,9 +30,9 @@ information about the offset from UTC time and the time zone name.
 
 The following classes are provided:
 
-* :class:`~timedelta`
-* :class:`~timezone`
-* :class:`~datetime`
+* :class:`timedelta`
+* :class:`timezone`
+* :class:`datetime`
 
 
 timedelta Objects
@@ -103,7 +103,13 @@ exact (no information is lost).
 
 .. method:: add(other)
 
-   Return the difference between two durations.
+   Return a :class:`timedelta` which represents the sum of two durations.
+
+
+.. method:: sub(other)
+
+   Return a :class:`timedelta` which represents the difference between
+   two durations.
 
 
 .. method:: mul(other)
@@ -211,6 +217,7 @@ Examples of timedelta arithmetic::
     print(nine_years)                   # 3285d 00:00:00
     three_years = nine_years.floordiv(3)
     print(three_years)                  # 1095d 00:00:00
+
 
 timezone Objects
 ================
@@ -396,6 +403,7 @@ to last Sunday of October). ::
     print(tz.isoformat(datetime(2011, 8, 1))) # UTC+02:00
     print(tz.tzname   (datetime(2011, 8, 1))) # CEST
 
+
 datetime Objects
 ================
 
@@ -439,6 +447,7 @@ Constructors
        YYYY-MM-DD[*HH[:MM[:SS[.fff[fff]]]][+HH:MM[:SS[.ffffff]]]]
 
    where ``*`` can match any single character.
+
 
 .. function:: fromordinal(n)
 


### PR DESCRIPTION
This pull request:

* provides methods `datetime.date()`, `datetime.time()` and function `combine()` to mimic Python's classes date and time
* fixes `datetime`'s `__init__()` that failed when adding a `deltatime` which resulted in a number of days greater than two months
* adds minor improvements.