### PR TITLE
Add built-in function id()

### DIFF
--- a/__builtins__.py
+++ b/__builtins__.py
@@ -292,6 +292,14 @@ Builtin Functions
         PFROZENSET, PSET, PDICT, PFUNCTION, PMETHOD, PCLASS, PINSTANCE, PMODULE, PITERATOR,
         PNONE, PEXCEPTION, PNATIVE, PSYSOBJ, PDRIVER, PTHREAD
 
+.. function:: id(ojbect)
+
+    Return the “identity” of an object. This is an integer which is guaranteed
+    to be unique and constant for this object during its lifetime. Two objects
+    with non-overlapping lifetimes may have the same `id()` value.
+
+    *Zerynth implementation detail:* This is the address of the object in memory.
+
 .. function:: thread(fun,*args,prio=PRIO_NORMAL,size=-1)
 
     Function *fun* is launched in a new thread using args as its parameters.
@@ -637,7 +645,10 @@ def thread(fn,*args,prio = PRIO_NORMAL, size=-1):
     pth.start()
     return pth
 
-
+@builtin
+@native_c("__builtin_id",["csrc/mcu/mcu.c"])
+def id(obj):
+    pass
 
 @builtin
 def print(*objects,sep=" ",end="\n", stream=None):

--- a/csrc/mcu/mcu.c
+++ b/csrc/mcu/mcu.c
@@ -1,5 +1,10 @@
 #include "zerynth.h"
 
+C_NATIVE(__builtin_id){
+  NATIVE_UNWARN();
+  *res = PSMALLINT_NEW((IS_TAGGED(args[0]) ? &args[0] : args[0]));
+  return ERR_OK;
+}
 
 C_NATIVE(_mcu_reset){
   NATIVE_UNWARN();


### PR DESCRIPTION
This pull request adds `id()` to built-in functions. It returns the "identity" of an object as much as CPython's [`id()`](https://docs.python.org/3/library/functions.html?highlight=id#id).

Note that, because there was no obvious file where storing the C source code, I chose `csrc/mcu/mcu.c`. Any other file will do.