### PR TITLE
struct: fix unpack_from() when buffer is bigger than calcsize

### DIFF
--- a/csrc/struct/struct.c
+++ b/csrc/struct/struct.c
@@ -630,7 +630,7 @@ C_NATIVE(__struct_unpack) {
     *res = MAKE_NONE();
 
     PackEntry *pes = pack_calc_size(fmt,fmtl,&mode,&items,&entries,&gsize);
-    if(!pes || gsize!=bufsize){
+    if(!pes || gsize>bufsize){
         err=1;
         goto clean_up;
     } 


### PR DESCRIPTION
As per documentation, the buffer’s size in bytes, minus offset, can be bigger than the size required by the format, as reflected by `calcsize()`.